### PR TITLE
fix accidentally unlocking table surface

### DIFF
--- a/src/tts/ttsjigsawjoin.ttslua
+++ b/src/tts/ttsjigsawjoin.ttslua
@@ -34,6 +34,9 @@ function onLoad(save_state)
 
   Wait.time(onWaitMain, 1, -1)
 
+  tableSurface = getObjectFromGUID("1f2767")
+  tableSurface.interactable = false
+
   debugPrint(string.format(
     'onLoad elapsed: %.2f',
     os.time() - start


### PR DESCRIPTION
On load, this makes the table surface uninteractable, just in case anyone presses the letter "L" while their mouse is not over anything.