### PR TITLE
changing the structure of the puzzle

### DIFF
--- a/src/tts/ttsjigsawjoin.ttslua
+++ b/src/tts/ttsjigsawjoin.ttslua
@@ -92,8 +92,9 @@ function serializeGameStateJSON()
           pieces[#pieces + 1] = '[]'
         else
           pieces[#pieces + 1] = string.format(
-            '{"joinedTo":%d,"player_name":"%s"}',
+            '{"joinedTo":%d,"parentId":%d,"player_name":"%s"}',
             pieceData.joinedTo,
+            pieceData.parentId,
             string.gsub(pieceData.player_name, '\\', '\\\\'):gsub('"', '\\"')
           )
         end
@@ -265,6 +266,24 @@ function onClick_CloseGreeting(player)
     tostring(player.team),
     os.time() - start
   ))
+end
+
+function iterJoinedTo(pieceId,include_self)
+  -- This iterator is safe against changing the returned value's data
+  include_self = include_self ~= false -- Default is false
+  local nextPieceId = gameState.pieces[pieceId].joinedTo
+  local startPieceId = pieceId
+  return function ()
+            if include_self then
+              include_self = false
+              return pieceId
+            end
+            local ret = nextPieceId
+            if ret ~= nil and ret ~= startPieceId then
+              nextPieceId = gameState.pieces[ret].joinedTo
+              return ret
+            end
+          end
 end
 
 -- this is unsafe during game shutdown!
@@ -645,7 +664,8 @@ function spawnPuzzle(templateId, picture)
   for x = 1, #templateData[gameState.templateId].pieces do
     gameState.pieces[x] = {
       player_name = nil,
-      joinedTo = nil
+      joinedTo = nil,
+      parentId = nil
     }
 
     local piece = spawnObject({
@@ -670,10 +690,8 @@ function showCredits()
   local allProjectedPieceCoordinates = {}
   for index, piece in ipairs(allPieces) do
     local pieceGroup = { piece.id }
-    for pieceId, pieceState in ipairs(gameState.pieces) do
-      if pieceState.joinedTo == piece.id then
-        pieceGroup[#pieceGroup + 1] = pieceId
-      end
+    for pieceId in iterJoinedTo(piece.id, false) do
+      pieceGroup[#pieceGroup + 1] = pieceId
     end
 
     for index, pieceId in ipairs(pieceGroup) do
@@ -1095,13 +1113,6 @@ function attachPieces(droppedPiece, targetPiece)
     targetPiece.object.addAttachment(attachment)
   end
 
-  for x = 1, #gameState.pieces do
-    local pieceState = gameState.pieces[x]
-    if pieceState.joinedTo == droppedPiece.id then
-      pieceState.joinedTo = targetPiece.id
-    end
-  end
-
   targetPiece.object.addAttachment(droppedPiece.object)
 
   debugPrint(string.format(
@@ -1175,58 +1186,45 @@ function onPieceDropped(player_color, droppedPiece)
   --))
 
   if activeMerges[droppedPiece.id] > 0 then return end
-  if gameState.pieces[droppedPiece.id].joinedTo ~= nil then return end
 
-  local droppedPieceGroup = { droppedPiece.id }
-  for pieceId, pieceState in ipairs(gameState.pieces) do
-    if pieceState.joinedTo == droppedPiece.id then
-      droppedPieceGroup[#droppedPieceGroup + 1] = pieceId
-    end
+  local droppedPieceGroup = {}
+  for pieceId in iterJoinedTo(droppedPiece.id) do
+    droppedPieceGroup[pieceId] = true
   end
 
   local candidateMatches = {}
-  for index, pieceId in ipairs(droppedPieceGroup) do
-    for index, targetId in ipairs(templateData[gameState.templateId].pieces[pieceId].neighbors) do
-      local candidateId = gameState.pieces[targetId].joinedTo or targetId
+  for pieceId, _ in pairs(droppedPieceGroup) do
+    for _, targetId in ipairs(templateData[gameState.templateId].pieces[pieceId].neighbors) do
+      targetId = gameState.pieces[targetId].parentId or targetId
 
-      if not table_contains(droppedPieceGroup, candidateId) and
-        not table_contains(candidateMatches, candidateId) then
-
-        candidateMatches[#candidateMatches + 1] = candidateId
+      if droppedPieceGroup[targetId] == nil then
+        candidateMatches[targetId] = true
       end
     end
   end
 
   local player = Player[player_color]
-
-  for index, targetId in ipairs(candidateMatches) do
+  for targetId, _ in pairs(candidateMatches) do
     local targetPiece = getPiece(targetId)
 
-    if targetPiece ~= nil and
-      gameState.pieces[targetPiece.id].joinedTo == nil and
-      arePiecesAligned(droppedPiece, targetPiece) then
-
-      joinPieces(player, droppedPiece, targetPiece)
-
-      break
-    end
+      if targetPiece ~= nil and targetPiece.object ~= nil and arePiecesAligned(droppedPiece, targetPiece) then
+        joinPieces(player, droppedPiece, targetPiece)
+        break
+      end
   end
 
   debugPrint(string.format(
-    'onPieceDropped player_color: %s, droppedPiece.id: %s, elapsed: %.2f, droppedPieceGroup[%d]: [%s], candidateMatches[%d]: [%s]',
+    'onPieceDropped player_color: %s, droppedPiece.id: %s, elapsed: %.2f',
     player_color,
     droppedPiece.id,
-    os.time() - start,
-    #droppedPieceGroup,
-    table.concat(droppedPieceGroup, ','),
-    #candidateMatches,
-    table.concat(candidateMatches, ',')
+    os.time() - start
   ))
 end
 
 
 function joinPieces(player, droppedPiece, targetPiece)
   activeMerges[targetPiece.id] = (activeMerges[targetPiece.id] or 0) + 1
+  activeMerges[droppedPiece.id] = (activeMerges[droppedPiece.id] or 0) + 1
 
   droppedPiece.object.interactable = false
 
@@ -1239,8 +1237,17 @@ function joinPieces(player, droppedPiece, targetPiece)
   teamState.score = teamState.score + 1
 
   local droppedPieceState = gameState.pieces[droppedPiece.id]
+  local targetPieceState = gameState.pieces[targetPiece.id]
   droppedPieceState.player_name = player.steam_name
-  droppedPieceState.joinedTo = targetPiece.id
+  targetPieceState.player_name = targetPieceState.player_name or player.steam_name
+
+  targetJoinedTo = targetPieceState.joinedTo
+  targetPieceState.joinedTo = droppedPieceState.joinedTo or droppedPiece.id
+  droppedPieceState.joinedTo = targetJoinedTo or targetPiece.id
+
+  for pieceId in iterJoinedTo(targetPiece.id) do
+    gameState.pieces[pieceId].parentId = targetPiece.id
+  end
 
   -- TODO save cache WIP
   pieceTextCache = ''
@@ -1250,9 +1257,10 @@ function joinPieces(player, droppedPiece, targetPiece)
   local toRunFunc = function()
     droppedPiece.object.interactable = true
 
-    activeMerges[targetPiece.id] = activeMerges[targetPiece.id] - 1
-
     attachPieces(droppedPiece, targetPiece)
+
+    activeMerges[targetPiece.id] = activeMerges[targetPiece.id] - 1
+    activeMerges[droppedPiece.id] = activeMerges[droppedPiece.id] - 1
 
     Wait.frames(onCheckSolution, 1)
   end


### PR DESCRIPTION
Keep two variables for a group of joined pieces.
"parentId":The pieceId of the parent piece that is still on the board.
"joinedTo":a circularly linked list of all the pieces that make up the group.

eg. if two pieces 45 and 87 are connected then
gameState.pieces[45]={joinedTo:87,parentId=45,player_name="jack"}
and
gameState.pieces[87]={joinedTo:45,parentId=45,player_name="jack"}

Since the "joinedTo" value points to the id of the next piece in the chain, these values can easily be corrupted, but I took care not to mess up the code for this.

New conventions, if the piece is unjoined, then parentId == joinedTo == nil. Also the parent id of the parent piece is its own id, instead of nil.

This implementation includes an iterator "iterJoinedTo". It takes the piece id of any piece and iterates through its own id and all the ids of the attached pieces.
for id in iterJoinedTo(45) do
print(id)
end
-- output is "45" then "87" then stops
To exclude itself, you can use iterJoinedTo(45,false) and it will only output "87" and stop.

The JSON save is updated.

It also assigns a name to both target piece and dropped piece if the name is blank, so that it will ping all pieces without any gaps.