### PR TITLE
make control panel background change size with open menus

### DIFF
--- a/src/tts/ttsjigsawjoin.ttslua
+++ b/src/tts/ttsjigsawjoin.ttslua
@@ -864,14 +864,26 @@ end
 
 function onClick_teamScoreBoardTitle(player, button, id)
   if not player.admin then return end
-  local show = (UI.getAttribute('teamScoreBoardRow', 'active') == 'true')
-  UI.setAttribute('teamScoreBoardRow', 'active', tostring(not show))
+  local show = UI.getAttribute('teamScoreBoardRow', 'active') ~= 'true'
+  local offsetX, offsetY = UI.getAttribute('controlPanel', 'offsetXY'):gmatch("(.*) (.*)")()
+  local height = tonumber(UI.getAttribute('controlPanel', 'height'))
+  local newheight = height + tonumber(UI.getAttribute('teamScoreBoardRow', 'preferredHeight')) * (show and 1 or -1) --
+  offsetY = tostring(tonumber(offsetY) - math.floor(math.abs((newheight - height) / 2)) * (newheight-height > 0 and 1 or -1))
+  UI.setAttribute('controlPanel', 'height', tostring(newheight))
+  UI.setAttribute('controlPanel', 'offsetXY', offsetX.." "..offsetY)
+  UI.setAttribute('teamScoreBoardRow', 'active', tostring(show))
 end
 
 function onClick_playerScoreBoardTitle(player, button, id)
   if not player.admin then return end
-  local show = (UI.getAttribute('playerScoreBoardRow', 'active') == 'true')
-  UI.setAttribute('playerScoreBoardRow', 'active', tostring(not show))
+  local show = UI.getAttribute('playerScoreBoardRow', 'active') ~= 'true'
+  local offsetX, offsetY = UI.getAttribute('controlPanel', 'offsetXY'):gmatch("(.*) (.*)")()
+  local height = tonumber(UI.getAttribute('controlPanel', 'height'))
+  local newheight = height + 374 * (show and 1 or -1)
+  offsetY = tostring(tonumber(offsetY) - math.floor(math.abs((newheight - height) / 2)) * (newheight-height > 0 and 1 or -1))
+  UI.setAttribute('controlPanel', 'height', tostring(newheight))
+  UI.setAttribute('controlPanel', 'offsetXY', offsetX.." "..offsetY)
+  UI.setAttribute('playerScoreBoardRow', 'active', tostring(show))
 end
 
 

--- a/src/tts/ttsjigsawjoin.xml
+++ b/src/tts/ttsjigsawjoin.xml
@@ -46,7 +46,7 @@
     childForceExpandWidth="false"
     childAlignment="MiddleRight" />
 </Defaults>
-<TableLayout class="jjWindow jjControlPanel">
+<TableLayout id="controlPanel" class="jjWindow jjControlPanel">
   <Row preferredHeight="50">
     <Cell>
       <VerticalLayout class="jjTitle">
@@ -72,7 +72,7 @@
       </VerticalLayout>
     </Cell>
   </Row>
-  <Row id="teamScoreBoardRow" active="false">
+  <Row id="teamScoreBoardRow" active="false" preferredHeight="180">
     <Cell>
       <VerticalScrollView color="" scrollSensitivity="30">
         <TableLayout id="teamScoreBoard" class="scoreBoard">


### PR DESCRIPTION
The control panel background is the minimum size of the sub-elements.
Team Score Board can have at most 6 teams, so I made it a fixed height of 6*30=180 pixels when expanded.
The player scoreboard still expands to fill the empty space.

Opening and closing the panel looks clean, even if the panel was dragged.