### PR TITLE
fix getPiece() function

### DIFF
--- a/src/tts/ttsjigsawjoin.ttslua
+++ b/src/tts/ttsjigsawjoin.ttslua
@@ -986,28 +986,49 @@ end
 -- Converts a TTS object type into a Piece type
 -- caches all object lookups but only returns valid pieces
 pieceCache = {}
-function getPiece(object)
+function getPiece(objectOrId)
   --debugPrint(string.format(
   --  'getPiece object: %s',
   --  tostring(object)
   --))
 
-  local piece = pieceCache[object]
+  local piece = pieceCache[objectOrId]
   if piece == nil then
-    piece = {
-      id = getPieceId(object),
-      object = object,
-      solutionPosition = nil
-    }
-    if piece.id ~= nil then
-      piece.solutionPosition = Vector(templateData[gameState.templateId].pieces[piece.id].solutionPosition)
-      piece.solutionRotation = Vector(templateData[gameState.templateId].pieces[piece.id].solutionRotation) + Vector(0, 180, 0)
-      pieceCache[piece.id] = piece
+    if type(objectOrId) == "number" then
+      -- Handle if objectOrId is a pieceId
+      local pieceId = objectOrId
+      for _, o in pairs(getObjects()) do
+        if getPieceId(o) == pieceId then
+          piece = {
+            id = pieceId,
+            object = o,
+            solutionPosition = nil
+          }
+          piece.solutionPosition = Vector(templateData[gameState.templateId].pieces[piece.id].solutionPosition)
+          piece.solutionRotation = Vector(templateData[gameState.templateId].pieces[piece.id].solutionRotation) + Vector(0, 180, 0)
+          pieceCache[piece.id] = piece
+          pieceCache[o] = piece
+        end
+      end
+    else
+      -- Handle if objectOrId is an object
+      local object = objectOrId
+      piece = {
+        id = getPieceId(object),
+        object = object,
+        solutionPosition = nil
+      }
+      if piece.id ~= nil then
+        piece.solutionPosition = Vector(templateData[gameState.templateId].pieces[piece.id].solutionPosition)
+        piece.solutionRotation = Vector(templateData[gameState.templateId].pieces[piece.id].solutionRotation) + Vector(0, 180, 0)
+        pieceCache[piece.id] = piece
+      end
+      pieceCache[object] = piece
     end
-    pieceCache[object] = piece
   end
-  if piece.id == nil then return end
-  return piece
+  if piece != nil and piece.id != nil then
+    return piece
+  end
 end
 
 


### PR DESCRIPTION
getPiece() has calls on lines 132, 152, 188, 216, 300, 584, 770, 787 and 1203
Some of which pass a TTS object as an argument and some, a pieceId as an argument.

getPiece() can handle an object not in "pieceCache" it caches it properly, but if it encounters a pieceId not in "pieceCache" then it errors and doesn't join a dropped piece.
The error is generated on line 950
"if object.tag == nil or object.tag ~= 'Generic' then return end"
of trying to get the ".tag" index of a number.

The fix is to handle both an object and pieceId separately and return a valid piece table for both(or nil if no such piece exists)